### PR TITLE
Fix that the UserHasValidClaim method couldn't handle some strings

### DIFF
--- a/src/NetDevPack.Identity/Authorization/CustomAuthorizationValidation.cs
+++ b/src/NetDevPack.Identity/Authorization/CustomAuthorizationValidation.cs
@@ -8,7 +8,9 @@ namespace NetDevPack.Identity.Authorization
         public static bool UserHasValidClaim(HttpContext context, string claimName, string claimValue)
         {
             return context.User.Identity.IsAuthenticated &&
-                   context.User.Claims.Any(c => c.Type == claimName && c.Value.Split(',').Contains(claimValue));
+                   context.User.Claims.Any(c => 
+                       c.Type == claimName && 
+                       c.Value.Split(',').Select(v => v.Trim()).Contains(claimValue));
         }
 
     }


### PR DESCRIPTION
UserHasValidClaim method couldn't correctly handle some strings that include space. For example, "Write, Remove" will be handled as an array that is like ["Write", " Remove"]. It is apparently incorrect.